### PR TITLE
Added option to print the step arguments (Table Node) on the report.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ formatters:
         name: html
         renderer: Twig,Behat2
         file_name: Index
+        print_table: true
 </pre>
 
 The *output* parameter is relative to %paths.base% and, when omitted, will default to that same path.
@@ -23,6 +24,8 @@ The *output* parameter is relative to %paths.base% and, when omitted, will defau
 The *renderer* is the renderer engine and the report format that you want to be generated.
 
 The *file_name* is optional. When it is added, the report name will be fixed instead fo generated, and this file will be overwritten with every build.
+
+The *print_args* is optional. When it is added, the report will contain the arguments for each step if exists. (e.g. Tables) 
 
 Actually, there is 3 formats :
 
@@ -39,11 +42,10 @@ File names have this format : *"renderer name"*_*"date hour"*
 To be done:
 ========================
 
-1. Store previous runs --> Done
-2. Add parameters for behat.yml file
-3. Add bootstrap as dependency
-4. clean up html report
-5. Add out parameter
+1. Add parameters for behat.yml file
+2. Add bootstrap as dependency
+3. clean up html report
+4. Add out parameter
 
 =========================
 

--- a/src/BehatHTMLFormatterExtension.php
+++ b/src/BehatHTMLFormatterExtension.php
@@ -54,6 +54,7 @@ class BehatHTMLFormatterExtension implements ExtensionInterface {
     $builder->children()->scalarNode("name")->defaultValue("emusehtml");
     $builder->children()->scalarNode("renderer")->defaultValue("behat2");
     $builder->children()->scalarNode("file_name")->defaultValue("generated");
+    $builder->children()->scalarNode("print_args")->defaultValue("false");
     $builder->children()->scalarNode('output')->defaultValue('.');
   }
 
@@ -68,6 +69,7 @@ class BehatHTMLFormatterExtension implements ExtensionInterface {
     $definition->addArgument($config['name']);
     $definition->addArgument($config['renderer']);
     $definition->addArgument($config['file_name']);
+    $definition->addArgument($config['print_args']);
 
     $definition->addArgument('%paths.base%');
     $container->setDefinition("html.formatter", $definition)

--- a/src/Formatter/BehatHTMLFormatter.php
+++ b/src/Formatter/BehatHTMLFormatter.php
@@ -78,6 +78,12 @@ class BehatHTMLFormatter implements Formatter {
   private $renderer;
 
   /**
+   * Flag used by this Formatter
+   * @param $print_args boolean
+   */
+  private $print_args;
+
+  /**
    * @var Array
    */
   private $suites;
@@ -147,13 +153,13 @@ class BehatHTMLFormatter implements Formatter {
    * @param $name
    * @param $base_path
    */
-  function __construct($name, $renderer, $filename, $base_path) {
+  function __construct($name, $renderer, $filename, $print_args, $base_path) {
     $this->name = $name;
+    $this->print_args = $print_args;
     $this->renderer = new BaseRenderer($renderer, $base_path);
     $this->printer = new FileOutputPrinter($this->renderer->getNameList(), $filename, $base_path);
     $this->timer = new Timer();
     $this->memory = new Memory();
-
   }
 
   /**
@@ -265,6 +271,15 @@ class BehatHTMLFormatter implements Formatter {
    */
   public function getOutputPath() {
     return $this->outputPath;
+  }
+
+  /**
+   * Returns if it should print the step arguments
+   *
+   * @return boolean
+   */
+  public function getPrintArguments() {
+    return $this->print_args;
   }
 
   public function getTimer() {

--- a/src/Renderer/TwigRenderer.php
+++ b/src/Renderer/TwigRenderer.php
@@ -46,6 +46,7 @@ class TwigRenderer
                 'passedSteps' => $obj->getPassedSteps(),
                 'failedFeatures' => $obj->getFailedFeatures(),
                 'passedFeatures' => $obj->getPassedFeatures(),
+                'printStepArgs' => $obj->getPrintArguments(),
             )
         );
 

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -184,10 +184,15 @@
                                         {% for step in scenario.steps %}
                                             <li class="list-group-item alert alert-{% if step.isPassed %}success{% elseif step.isSkipped %}info{% elseif step.isPending %}warning{% else %}danger{% endif %}">
                                                 <b>{{ step.keyword }}</b> {{ step.text }}
+                                                {% if printStepArgs is not null %}
+                                                    {% for argument in step.arguments %}
+                                                        <p style="padding-left:0.5em; overflow-x:scroll; white-space:nowrap; font-family:monospace">{{ argument | nl2br }}</p>
+                                                    {% endfor %}
+                                                {% endif %}
                                                 {% if step.exception is not null %}
                                                     <br>
                                                 <p style="padding-left:2em ; color:gray">({{ step.exception }})</p>
-                                            {% endif %}
+                                                {% endif %}
                                             </li>
                                             {#<div class="bs-callout bs-callout-{% if step.passed %}success{% else %}danger{% endif %}" id="callout-collapse-accessibility">#}
                                             {#<b>{{ step.keyword }}</b> {{ step.text }}#}


### PR DESCRIPTION
Just a improvement I was needing for my reporting tasks. I was wondering if would be useful to somebody else.

Set it as optional so and configurable trough the behat.yml. Default is false.

If print_args is set to true, and there are step arguments, it will look like this:
![screen shot 2015-05-05 at 19 13 19](https://cloud.githubusercontent.com/assets/2047805/7484078/35d9ba56-f35b-11e4-8758-6afd2c3e5928.png)
