### PR TITLE
#32 Add render options - WP

### DIFF
--- a/src/BehatHTMLFormatterExtension.php
+++ b/src/BehatHTMLFormatterExtension.php
@@ -58,6 +58,14 @@ class BehatHTMLFormatterExtension implements ExtensionInterface {
     $builder->children()->scalarNode("print_outp")->defaultValue("false");
     $builder->children()->scalarNode("loop_break")->defaultValue("false");
     $builder->children()->scalarNode('output')->defaultValue('.');
+    $builder
+        ->children()
+            ->arrayNode('render_options')
+                ->defaultValue(array())
+                ->prototype('scalar')->end()
+            ->end()
+        ->end()
+    ;
   }
 
   /**
@@ -70,6 +78,7 @@ class BehatHTMLFormatterExtension implements ExtensionInterface {
     $definition = new Definition("emuse\\BehatHTMLFormatter\\Formatter\\BehatHTMLFormatter");
     $definition->addArgument($config['name']);
     $definition->addArgument($config['renderer']);
+    $definition->addArgument($config['render_options']);
     $definition->addArgument($config['file_name']);
     $definition->addArgument($config['print_args']);
     $definition->addArgument($config['print_outp']);

--- a/src/Formatter/BehatHTMLFormatter.php
+++ b/src/Formatter/BehatHTMLFormatter.php
@@ -165,12 +165,12 @@ class BehatHTMLFormatter implements Formatter {
    * @param $name
    * @param $base_path
    */
-  function __construct($name, $renderer, $filename, $print_args, $print_outp, $loop_break, $base_path) {
+  function __construct($name, $renderer, $render_options, $filename, $print_args, $print_outp, $loop_break, $base_path) {
     $this->name = $name;
     $this->print_args = $print_args;
     $this->print_outp = $print_outp;
     $this->loop_break = $loop_break;
-    $this->renderer = new BaseRenderer($renderer, $base_path);
+    $this->renderer = new BaseRenderer($renderer, $render_options, $base_path);
     $this->printer = new FileOutputPrinter($this->renderer->getNameList(), $filename, $base_path);
     $this->timer = new Timer();
     $this->memory = new Memory();

--- a/src/Formatter/BehatHTMLFormatter.php
+++ b/src/Formatter/BehatHTMLFormatter.php
@@ -170,7 +170,7 @@ class BehatHTMLFormatter implements Formatter {
     $this->print_args = $print_args;
     $this->print_outp = $print_outp;
     $this->loop_break = $loop_break;
-    $this->renderer = new BaseRenderer($renderer, $render_options, $base_path);
+    $this->renderer = new BaseRenderer($renderer, $render_options);
     $this->printer = new FileOutputPrinter($this->renderer->getNameList(), $filename, $base_path);
     $this->timer = new Timer();
     $this->memory = new Memory();

--- a/src/Renderer/BaseRenderer.php
+++ b/src/Renderer/BaseRenderer.php
@@ -30,7 +30,7 @@ class BaseRenderer
      * @param string : list of the renderer
      * @param string : base_path
      */
-    public function __construct($renderer, $base_path)
+    public function __construct($renderer, $render_options, $base_path)
     {
         $rendererListTmp = explode(',', $renderer) ;
         
@@ -41,7 +41,7 @@ class BaseRenderer
         foreach($rendererListTmp as $r) {
             $this->nameList[] = $r ;
             $className = __NAMESPACE__ . '\\' . $r . 'Renderer' ;
-            $this->rendererList[$r] = new $className() ;  
+            $this->rendererList[$r] = new $className($render_options) ;
         }
     }
     

--- a/src/Renderer/BaseRenderer.php
+++ b/src/Renderer/BaseRenderer.php
@@ -30,7 +30,7 @@ class BaseRenderer
      * @param string : list of the renderer
      * @param string : base_path
      */
-    public function __construct($renderer, $render_options, $base_path)
+    public function __construct($renderer, $render_options)
     {
         $rendererListTmp = explode(',', $renderer) ;
         
@@ -41,7 +41,11 @@ class BaseRenderer
         foreach($rendererListTmp as $r) {
             $this->nameList[] = $r ;
             $className = __NAMESPACE__ . '\\' . $r . 'Renderer' ;
-            $this->rendererList[$r] = new $className($render_options) ;
+            $renderer_instance = new $className() ;
+            if ($render_options) {
+                $renderer_instance->setRenderOptions($render_options);
+            }
+            $this->rendererList[$r] = $renderer_instance;
         }
     }
     

--- a/src/Renderer/TwigRenderer.php
+++ b/src/Renderer/TwigRenderer.php
@@ -10,10 +10,16 @@ use Twig_Loader_Filesystem;
 
 class TwigRenderer
 {
-
-    public function __construct()
+    protected $twigTemplateName;
+    protected $twigTemplatePath;
+    
+    public function __construct($render_options)
     {
-
+        $this->twigTemplateName = dirname(__FILE__) . '/../../templates';
+        $this->twigTemplatePath = 'index.html.twig';
+        foreach ($render_options as $renderOptionName => $renderOptionValue) {
+            $this->$renderOptionName = $renderOptionValue;
+        }
     }
 
     /**
@@ -34,10 +40,9 @@ class TwigRenderer
      */
     public function renderAfterExercise($obj) {
 
-        $templatePath = dirname(__FILE__) . '/../../templates';
-        $loader = new Twig_Loader_Filesystem($templatePath);
+        $loader = new Twig_Loader_Filesystem($this->twigTemplatePath);
         $twig = new Twig_Environment($loader, array());
-        $print = $twig->render('index.html.twig',
+        $print = $twig->render($this->twig_template,
             array(
                 'suites' => $obj->getSuites(),
                 'failedScenarios' => $obj->getFailedScenarios(),

--- a/src/Renderer/TwigRenderer.php
+++ b/src/Renderer/TwigRenderer.php
@@ -10,15 +10,13 @@ use Twig_Loader_Filesystem;
 
 class TwigRenderer
 {
-    protected $twigTemplateName;
-    protected $twigTemplatePath;
+    private $twig_template_name = 'index.html.twig';
+    private $twig_template_path = __DIR__. '/../../templates';
     
-    public function __construct($render_options)
+    public function setRenderOptions(array $render_options)
     {
-        $this->twigTemplateName = dirname(__FILE__) . '/../../templates';
-        $this->twigTemplatePath = 'index.html.twig';
-        foreach ($render_options as $renderOptionName => $renderOptionValue) {
-            $this->$renderOptionName = $renderOptionValue;
+        foreach ($render_options as $render_option_name => $render_option_value) {
+            $this->$render_option_name = $render_option_value;
         }
     }
 
@@ -40,9 +38,9 @@ class TwigRenderer
      */
     public function renderAfterExercise($obj) {
 
-        $loader = new Twig_Loader_Filesystem($this->twigTemplatePath);
+        $loader = new Twig_Loader_Filesystem($this->twig_template_path);
         $twig = new Twig_Environment($loader, array());
-        $print = $twig->render($this->twig_template,
+        $print = $twig->render($this->twig_template_name,
             array(
                 'suites' => $obj->getSuites(),
                 'failedScenarios' => $obj->getFailedScenarios(),


### PR DESCRIPTION
#32 This adds the possibility to set render options like this:

```
render_options: 
     twig_template_name: index.html.twig
     twig_template_path: build/templates
```

The render options can be anything but they must match the attributes of the render.
I did this to add more flexibility.
What do you think?
