### PR TITLE
Fixing html escaping in Scenario output of Behat2 renderer

### DIFF
--- a/src/Renderer/Behat2Renderer.php
+++ b/src/Renderer/Behat2Renderer.php
@@ -90,7 +90,7 @@ class Behat2Renderer implements RendererInterface {
         if(count($obj->getPendingSteps()) > 0) {
             foreach($obj->getPendingSteps() as $pendingStep) {
                 $strPendingList .= '
-                    <li>'.$pendingStep->getKeyword().' '.$pendingStep->getText().'</li>';
+                    <li>'.$pendingStep->getKeyword().' '.htmlentities($pendingStep->getText()).'</li>';
             }
             $strPendingList = '
             <div class="pending">Pending steps :
@@ -338,7 +338,7 @@ class Behat2Renderer implements RendererInterface {
                     <li class="'.$stepResultClass.'">
                         <div class="step">
                             <span class="keyword">'.$step->getKeyWord().' </span>
-                            <span class="text">'.$step->getText().' </span>
+                            <span class="text">'.htmlentities($step->getText()).' </span>
                             <span class="path">'.$strPath.'</span>
                         </div>';
         $exception = $step->getException();


### PR DESCRIPTION
if a scenario contains some html chars in the text, html output can be broken `And the response should contain "<!--[if IE 9]>"`. in this case all output lines after not visible because of invalid html structure
