### PR TITLE
Fixing Screenshot path allowing custom output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Activate the extension by specifying its class in your `behat.yml`:
 default:
   suites:
     ... # All your awesome suites come here
-  
-  formatters: 
+
+  formatters:
     html:
       output_path: %paths.base%/build/html/behat
-      
+
   extensions:
     emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
       name: html
@@ -89,7 +89,12 @@ default:
 
 ## Configuration
 
-* `output_path` - The location where Behat will save the HTML reports. The path defined here is relative to `%paths.base%` and, when omitted, will be default set to the same path.
+### Formatter configuration
+
+* `output_path` - The location where Behat will save the HTML reports. Use `%paths.base%` to build the full path.
+
+### Extension configuration
+
 * `renderer` - The engine that Behat will use for rendering, thus the types of report format Behat should output (multiple report formats are allowed, separate them by commas). Allowed values are:
  * *Behat2* for generating HTML reports like they were generated in Behat 2.
  * *Twig* A new and more modern format based on Twig.
@@ -138,23 +143,25 @@ Below is an example of FeatureContext methods which will produce an image file i
             {
                 //create filename string
                 $featureFolder = str_replace(' ', '', $scope->getFeature()->getTitle());
-    
+
                 $scenarioName = $this->currentScenario->getTitle();
                 $fileName = str_replace(' ', '', $scenarioName) . '.png';
-    
+
                 //create screenshots directory if it doesn't exist
                 if (!file_exists('results/html/assets/screenshots/' . $featureFolder)) {
                     mkdir('results/html/assets/screenshots/' . $featureFolder);
                 }
-    
+
                 //take screenshot and save as the previously defined filename
                 $this->driver->takeScreenshot('results/html/assets/screenshots/' . $featureFolder . '/' . $fileName);
+                // For Selenium2 Driver you can use:
+                // file_put_contents('results/html/assets/screenshots/' . $featureFolder . '/' . $fileName, $this->getSession()->getDriver()->getScreenshot());
             }
         }
-        
+
 ```
 
-Note that the currentScenario variable will need to be at class level and generated in the @BeforeScenario method as Behat does not currently support obtaining the current Scenario in the @AfterStep method, where the screenshot is generated 
+Note that the currentScenario variable will need to be at class level and generated in the @BeforeScenario method as Behat does not currently support obtaining the current Scenario in the @AfterStep method, where the screenshot is generated
 
 ## Issue Submission
 

--- a/src/BehatHTMLFormatterExtension.php
+++ b/src/BehatHTMLFormatterExtension.php
@@ -57,7 +57,6 @@ class BehatHTMLFormatterExtension implements ExtensionInterface {
     $builder->children()->scalarNode("print_args")->defaultValue("false");
     $builder->children()->scalarNode("print_outp")->defaultValue("false");
     $builder->children()->scalarNode("loop_break")->defaultValue("false");
-    $builder->children()->scalarNode('output')->defaultValue('.');
   }
 
   /**

--- a/src/Formatter/BehatHTMLFormatter.php
+++ b/src/Formatter/BehatHTMLFormatter.php
@@ -16,7 +16,6 @@ use Behat\Testwork\EventDispatcher\Event\AfterExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
 use Behat\Testwork\EventDispatcher\Event\BeforeExerciseCompleted;
 use Behat\Testwork\EventDispatcher\Event\BeforeSuiteTested;
-use Behat\Testwork\Output\Exception\BadOutputPathException;
 use Behat\Testwork\Output\Formatter;
 use Behat\Testwork\Output\Printer\OutputPrinter;
 use emuse\BehatHTMLFormatter\Classes\Feature;
@@ -255,45 +254,12 @@ class BehatHTMLFormatter implements Formatter {
     }
 
     /**
-     * Verify that the specified output path exists or can be created,
-     * then sets the output path.
-     * @param String $path Output path relative to %paths.base%
-     * @throws BadOutputPathException
-     */
-    public function setOutputPath($path)
-    {
-        $outpath = realpath($this->base_path.DIRECTORY_SEPARATOR.$path);
-        if(!file_exists($outpath)) {
-            if(!mkdir($outpath, 0755, true)) {
-                throw new BadOutputPathException(
-                    sprintf(
-                        'Output path %s does not exist and could not be created!',
-                        $outpath
-                    ),
-                    $outpath
-                );
-            }
-        } else {
-            if(!is_dir($outpath)) {
-                throw new BadOutputPathException(
-                    sprintf(
-                        'The argument to `output` is expected to the a directory, but got %s!',
-                        $outpath
-                    ),
-                    $outpath
-                );
-            }
-        }
-        $this->outputPath = $outpath;
-    }
-
-    /**
      * Returns output path
      * @return String output path
      */
     public function getOutputPath()
     {
-        return $this->outputPath;
+        return $this->printer->getOutputPath();
     }
 
     /**

--- a/src/Renderer/Behat2Renderer.php
+++ b/src/Renderer/Behat2Renderer.php
@@ -344,7 +344,7 @@ class Behat2Renderer implements RendererInterface {
         $exception = $step->getException();
         if(!empty($exception)) {
             $relativeScreenshotPath = 'assets/screenshots/' . $feature->getScreenshotFolder() . '/' . $scenario->getScreenshotName();
-            $fullScreenshotPath = $obj->getBasePath() . '/results/html/' . $relativeScreenshotPath;
+            $fullScreenshotPath = $obj->getOutputPath() . '/' . $relativeScreenshotPath;
             $print .= '
                         <pre class="backtrace">'.$step->getException().'</pre>';
             if(file_exists($fullScreenshotPath))


### PR DESCRIPTION
The screenshot feature has the `/results/html/` path hardcoded, due to that, the feature can not be used if you set a custom `output_path`. This PR fixes it and uses the output path instead.

Let me know any issue with or if want me to change something.

It will be great if you bump a new version also to avoid using `dev-master` in composer (`0.1.0` version is too old).

Kind regards.
