### PR TITLE
Fix path name to screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Below is an example of FeatureContext methods which will produce an image file i
             if(!$scope->getTestResult()->isPassed())
             {
                 //create filename string
-                $featureFolder = str_replace(' ', '', $scope->getFeature()->getTitle());
+                $featureFolder = preg_replace('/\W/', '', $scope->getFeature()->getTitle());
     
                 $scenarioName = $this->currentScenario->getTitle();
-                $fileName = str_replace(' ', '', $scenarioName) . '.png';
+                $fileName = preg_replace('/\W/', '', $scenarioName) . '.png';
     
                 //create screenshots directory if it doesn't exist
                 if (!file_exists('results/html/assets/screenshots/' . $featureFolder)) {

--- a/src/Classes/Feature.php
+++ b/src/Classes/Feature.php
@@ -108,7 +108,7 @@ class Feature
      */
     public function setScreenshotFolder($featureName)
     {
-        $this->screenshotFolder = str_replace(' ','', $featureName);
+        $this->screenshotFolder = preg_replace('/\W/', '', $featureName);
     }
 
     /**

--- a/src/Classes/Scenario.php
+++ b/src/Classes/Scenario.php
@@ -54,7 +54,7 @@ class Scenario
 
     public function setScreenshotName($scenarioName)
     {
-        $this->screenshotName = str_replace(' ','', $scenarioName) . '.png';
+        $this->screenshotName = preg_replace('/\W/', '', $scenarioName) . '.png';
     }
 
     /**


### PR DESCRIPTION
Sometimes we can find `.()""/\` in the feature/scenario name - so will be fine to avoid problems accessing files.
