### PR TITLE
Fix pending status in reports

### DIFF
--- a/assets/Twig/css/style.css
+++ b/assets/Twig/css/style.css
@@ -153,6 +153,11 @@ body {
   background-color: #00a65a;
   background-image: none;
 }
+#scenario-overview .feature .details .panel.pending > .panel-heading {
+  color: white;
+  background-color: #e38d13;
+  background-image: none;
+}
 #scenario-overview .feature .details .panel.failed > .panel-heading {
   color: white;
   background-color: #f56956;

--- a/assets/Twig/css/style.less
+++ b/assets/Twig/css/style.less
@@ -3,6 +3,7 @@
 
 @color-failed: #F56956;
 @color-passed: #00a65a;
+@color-pending: #e38d13;
 
 body {
   background-color: #f9f9f9;
@@ -123,6 +124,13 @@ body {
           > .panel-heading {
             color: white;
             background-color: @color-passed;
+            background-image: none;
+          }
+        }
+        &.pending {
+          > .panel-heading {
+            color: white;
+            background-color: @color-pending;
             background-image: none;
           }
         }

--- a/src/Classes/Feature.php
+++ b/src/Classes/Feature.php
@@ -19,6 +19,7 @@ class Feature
     private $file;
     private $screenshotFolder;
     private $failedScenarios = 0;
+    private $pendingScenarios = 0;
     private $passedScenarios = 0;
     private $scenarioCounter = 1;
 
@@ -161,6 +162,27 @@ class Feature
     /**
      * @return mixed
      */
+    public function getPendingScenarios()
+    {
+        return $this->pendingScenarios;
+    }
+
+    /**
+     * @param mixed $pendingScenarios
+     */
+    public function setPendingScenarios($pendingScenarios)
+    {
+        $this->pendingScenarios = $pendingScenarios;
+    }
+
+    public function addPendingScenario($number = 1)
+    {
+        $this->pendingScenarios++;
+    }
+
+    /**
+     * @return mixed
+     */
     public function getPassedScenarios()
     {
         return $this->passedScenarios;
@@ -219,6 +241,11 @@ class Feature
         return ($this->getPassedScenarios() / ($this->getTotalAmountOfScenarios())) * 100;
     }
 
+    public function getPercentPending()
+    {
+        return ($this->getPendingScenarios() / ($this->getTotalAmountOfScenarios())) * 100;
+    }
+
     public function getPercentFailed()
     {
         return ($this->getFailedScenarios() / ($this->getTotalAmountOfScenarios())) * 100;
@@ -226,7 +253,7 @@ class Feature
 
     public function getTotalAmountOfScenarios()
     {
-        return $this->getPassedScenarios() + $this->getFailedScenarios();
+        return $this->getPassedScenarios() + $this->getPendingScenarios() + $this->getFailedScenarios();
     }
     //</editor-fold>
 }

--- a/src/Classes/Feature.php
+++ b/src/Classes/Feature.php
@@ -156,7 +156,7 @@ class Feature
 
     public function addFailedScenario($number = 1)
     {
-        $this->failedScenarios++;
+        $this->failedScenarios += $number;
     }
 
     /**
@@ -177,7 +177,7 @@ class Feature
 
     public function addPendingScenario($number = 1)
     {
-        $this->pendingScenarios++;
+        $this->pendingScenarios += $number;
     }
 
     /**
@@ -198,7 +198,7 @@ class Feature
 
     public function addPassedScenario($number = 1)
     {
-        $this->passedScenarios++;
+        $this->passedScenarios += $number;
     }
 
     /**

--- a/src/Classes/Scenario.php
+++ b/src/Classes/Scenario.php
@@ -27,6 +27,11 @@ class Scenario
     private $passed;
 
     /**
+     * @var bool
+     */
+    private $pending;
+
+    /**
      * @var Step[]
      */
     private $steps;
@@ -118,6 +123,22 @@ class Scenario
     public function setPassed($passed)
     {
         $this->passed = $passed;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isPending()
+    {
+        return $this->pending;
+    }
+
+    /**
+     * @param boolean $pending
+     */
+    public function setPending($pending)
+    {
+        $this->pending = $pending;
     }
 
     /**

--- a/src/Formatter/BehatHTMLFormatter.php
+++ b/src/Formatter/BehatHTMLFormatter.php
@@ -9,7 +9,9 @@ use Behat\Behat\EventDispatcher\Event\AfterStepTested;
 use Behat\Behat\EventDispatcher\Event\BeforeFeatureTested;
 use Behat\Behat\EventDispatcher\Event\BeforeOutlineTested;
 use Behat\Behat\EventDispatcher\Event\BeforeScenarioTested;
+use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Tester\Result\ExecutedStepResult;
+use Behat\Behat\Tester\Result\StepResult;
 use Behat\Testwork\Counter\Memory;
 use Behat\Testwork\Counter\Timer;
 use Behat\Testwork\EventDispatcher\Event\AfterExerciseCompleted;
@@ -121,6 +123,11 @@ class BehatHTMLFormatter implements Formatter {
      * @var Scenario[]
      */
     private $failedScenarios;
+
+    /**
+     * @var Scenario[]
+     */
+    private $pendingScenarios;
 
     /**
      * @var Scenario[]
@@ -329,6 +336,11 @@ class BehatHTMLFormatter implements Formatter {
         return $this->failedScenarios;
     }
 
+    public function getPendingScenarios()
+    {
+        return $this->pendingScenarios;
+    }
+
     public function getPassedScenarios()
     {
         return $this->passedScenarios;
@@ -470,16 +482,22 @@ class BehatHTMLFormatter implements Formatter {
     {
         $scenarioPassed = $event->getTestResult()->isPassed();
 
-        if($scenarioPassed) {
+        if ($scenarioPassed) {
             $this->passedScenarios[] = $this->currentScenario;
             $this->currentFeature->addPassedScenario();
+            $this->currentScenario->setPassed(true);
+        } elseif ($event->getTestResult()->getResultCode() == StepResult::PENDING) {
+            $this->pendingScenarios[] = $this->currentScenario;
+            $this->currentFeature->addPendingScenario();
+            $this->currentScenario->setPending(true);
         } else {
             $this->failedScenarios[] = $this->currentScenario;
             $this->currentFeature->addFailedScenario();
+            $this->currentScenario->setPassed(false);
+            $this->currentScenario->setPending(false);
         }
 
         $this->currentScenario->setLoopCount(1);
-        $this->currentScenario->setPassed($event->getTestResult()->isPassed());
         $this->currentFeature->addScenario($this->currentScenario);
 
         $print = $this->renderer->renderAfterScenario($this);
@@ -508,16 +526,22 @@ class BehatHTMLFormatter implements Formatter {
     {
         $scenarioPassed = $event->getTestResult()->isPassed();
 
-        if($scenarioPassed) {
+        if ($scenarioPassed) {
             $this->passedScenarios[] = $this->currentScenario;
             $this->currentFeature->addPassedScenario();
+            $this->currentScenario->setPassed(true);
+        } elseif ($event->getTestResult()->getResultCode() == StepResult::PENDING) {
+            $this->pendingScenarios[] = $this->currentScenario;
+            $this->currentFeature->addPendingScenario();
+            $this->currentScenario->setPending(true);
         } else {
             $this->failedScenarios[] = $this->currentScenario;
             $this->currentFeature->addFailedScenario();
+            $this->currentScenario->setPassed(false);
+            $this->currentScenario->setPending(false);
         }
 
         $this->currentScenario->setLoopCount(sizeof($event->getTestResult()));
-        $this->currentScenario->setPassed($event->getTestResult()->isPassed());
         $this->currentFeature->addScenario($this->currentScenario);
 
         $print = $this->renderer->renderAfterOutline($this);
@@ -570,8 +594,12 @@ class BehatHTMLFormatter implements Formatter {
                     $step->setDefinition($result->getStepDefinition());
                     $exception = $result->getException();
                     if($exception) {
-                        $step->setException($exception->getMessage());
-                        $this->failedSteps[] = $step;
+                        if ($exception instanceof PendingException) {
+                            $this->pendingSteps[] = $step;
+                        } else {
+                            $step->setException($exception->getMessage());
+                            $this->failedSteps[] = $step;
+                        }
                     } else {
                         $step->setOutput($result->getCallResult()->getStdOut());
                         $this->passedSteps[] = $step;

--- a/src/Renderer/Behat2Renderer.php
+++ b/src/Renderer/Behat2Renderer.php
@@ -56,6 +56,11 @@ class Behat2Renderer implements RendererInterface {
             $strScePassed = ' <strong class="passed">'.count($obj->getPassedScenarios()).' success</strong>';
         }
 
+        $strScePending = '';
+        if(count($obj->getPendingScenarios()) > 0) {
+            $strScePending = ' <strong class="pending">'.count($obj->getPendingScenarios()).' pending</strong>';
+        }
+
         $strSceFailed = '';
         if(count($obj->getFailedScenarios()) > 0) {
             $strSceFailed = ' <strong class="failed">'.count($obj->getFailedScenarios()).' fail</strong>';
@@ -84,7 +89,7 @@ class Behat2Renderer implements RendererInterface {
 
         //totals
         $featTotal = (count($obj->getFailedFeatures()) + count($obj->getPassedFeatures()));
-        $sceTotal = (count($obj->getFailedScenarios()) + count($obj->getPassedScenarios()));
+        $sceTotal = (count($obj->getFailedScenarios()) + count($obj->getPendingScenarios()) + count($obj->getPassedScenarios()));
         $stepsTotal = (count($obj->getFailedSteps()) + count($obj->getPassedSteps()) + count($obj->getSkippedSteps()) + count($obj->getPendingSteps()));
 
         //list of pending steps to display
@@ -108,7 +113,7 @@ class Behat2Renderer implements RendererInterface {
                     '.$featTotal.' features ('.$strFeatPassed.$strFeatFailed.' )
                 </p>
                 <p class="scenarios">
-                    '.$sceTotal.' scenarios ('.$strScePassed.$strSceFailed.' )
+                    '.$sceTotal.' scenarios ('.$strScePassed.$strScePending.$strSceFailed.' )
                 </p>
                 <p class="steps">
                     '.$stepsTotal.' steps ('.$strStepsPassed.$strStepsPending.$strStepsSkipped.$strStepsFailed.' )

--- a/src/Renderer/MinimalRenderer.php
+++ b/src/Renderer/MinimalRenderer.php
@@ -41,6 +41,7 @@ class MinimalRenderer
         $strFeatPassed = count($obj->getPassedFeatures());
         $strFeatFailed = count($obj->getFailedFeatures());
         $strScePassed = count($obj->getPassedScenarios());
+        $strScePending = count($obj->getPendingScenarios());
         $strSceFailed = count($obj->getFailedScenarios());
         $strStepsPassed = count($obj->getPassedSteps());
         $strStepsPending = count($obj->getPendingSteps());
@@ -48,11 +49,11 @@ class MinimalRenderer
         $strStepsFailed = count($obj->getFailedSteps());
  
         $featTotal = (count($obj->getFailedFeatures()) + count($obj->getPassedFeatures()));
-        $sceTotal = (count($obj->getFailedScenarios()) + count($obj->getPassedScenarios())) ;
+        $sceTotal = (count($obj->getFailedScenarios()) + count($obj->getPendingScenarios()) + count($obj->getPassedScenarios())) ;
         $stepsTotal = (count($obj->getFailedSteps()) + count($obj->getPassedSteps()) + count($obj->getSkippedSteps()) + count($obj->getPendingSteps())) ;
 
         $print = $featTotal.','.$strFeatPassed.','.$strFeatFailed."\n";
-        $print.= $sceTotal.','.$strScePassed.','.$strSceFailed."\n";
+        $print.= $sceTotal.','.$strScePassed.','.$strScePending.','.$strSceFailed."\n";
         $print.= $stepsTotal.','.$strStepsPassed.','.$strStepsFailed.','.$strStepsSkipped.','.$strStepsPending."\n";
         $print.= $obj->getTimer().','.$obj->getMemory()."\n";
 

--- a/src/Renderer/TwigRenderer.php
+++ b/src/Renderer/TwigRenderer.php
@@ -41,6 +41,7 @@ class TwigRenderer
             array(
                 'suites' => $obj->getSuites(),
                 'failedScenarios' => $obj->getFailedScenarios(),
+                'pendingScenarios' => $obj->getPendingScenarios(),
                 'passedScenarios' => $obj->getPassedScenarios(),
                 'failedSteps' => $obj->getFailedSteps(),
                 'passedSteps' => $obj->getPassedSteps(),

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -62,7 +62,7 @@
             <div class="canvas-holder">
                 <canvas id="chart-scenarios" width="300" height="300"/>
             </div>
-            {{ failedScenarios|length }} scenarios failed of {{ (failedScenarios|length) + (passedScenarios|length) }}
+            {{ failedScenarios|length }} scenarios failed of {{ (failedScenarios|length) + (passedScenarios|length) + (pendingScenarios|length) }}
             scenarios
         </div>
         <div class="col-sm-4">
@@ -103,9 +103,12 @@
                                         </div>
                                         {% if feature.getTotalAmountOfScenarios > 0 %}
                                             <div class="progress">
-
                                                 <div class="progress-bar progress-bar-green" role="progressbar"
                                                      style="width: {{ feature.getPercentPassed }}%">
+                                                    <span class="sr-only">40% Complete (success)</span>
+                                                </div>
+                                                <div class="progress-bar progress-bar-warning" role="progressbar"
+                                                     style="width: {{ feature.getPercentPending }}%">
                                                     <span class="sr-only">40% Complete (success)</span>
                                                 </div>
                                                 <div class="progress-bar progress-bar-red" role="progressbar"
@@ -144,9 +147,12 @@
                                 </div>
                                 {% if feature.getTotalAmountOfScenarios > 0 %}
                                     <div class="progress">
-
                                         <div class="progress-bar progress-bar-green" role="progressbar"
                                              style="width: {{ feature.getPercentPassed }}%">
+                                            <span class="sr-only">40% Complete (success)</span>
+                                        </div>
+                                        <div class="progress-bar progress-bar-warning" role="progressbar"
+                                             style="width: {{ feature.getPercentPending }}%">
                                             <span class="sr-only">40% Complete (success)</span>
                                         </div>
                                         <div class="progress-bar progress-bar-red" role="progressbar"
@@ -160,7 +166,7 @@
                     </div>
                     <div class="col-sm-8 details panel-group" role="tablist" aria-multiselectable="true">
                         {% for scenario in feature.scenarios %}
-                            <div class="panel panel-default {% if scenario.isPassed %}passed{% else %}failed{% endif %}">
+                            <div class="panel panel-default {% if scenario.isPassed %}passed{% elseif scenario.isPending %}pending{% else %}failed{% endif %}">
                                 <div class="panel-heading" role="tab">
                                     <h4 class="panel-title">
                                         <a data-toggle="collapse" data-parent="#accordion"
@@ -245,6 +251,12 @@
             label: "Failed"
         },
         {
+            value: {{ pendingScenarios|length}},
+            color: "#e38d13",
+            highlight: "#eea236",
+            label: "Pending"
+        },
+        {
             value: {{  passedScenarios|length}},
             color: "#00a65a",
             highlight: "#5AD3D1",
@@ -301,6 +313,11 @@
             showOverview();
             $('.feature').hide();
             $('.card.failed').parent().show();
+        });
+        $('.filters #feature-pending-filter').click(function () {
+            showOverview();
+            $('.feature').hide();
+            $('.card.pending').parent().show();
         });
         $('.filters #feature-passed-filter').click(function () {
             showOverview();


### PR DESCRIPTION
Behat discriminate failed and pending tests and scenarios.
At our company, we had an inconsistency where our Jenkins build was marked as "passed" but the reports generated by your plugin marked all pending tests as "failed".
We want to keep pending tests in our suites to have a 100% coverage in the gherkins features files. Then the pending tests allow us to say : "we cover 80% in our continuous integration system and 20% remain manual tests".

This pull request retrieve those pending tests/scenarios information from behat and shows them in the reports.
