### PR TITLE
fixed issue with multi nodes params

### DIFF
--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -290,7 +290,8 @@
         $("#scenario-overview .feature[data-id='" + featureId + "']").show();
     }
     $(function () {
-        $('.collapse').collapse();
+        // hacky fix bug with destroyed layout cause JS error here
+        //$('.collapse').collapse();
 
         $('.filters').click()
         {

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -186,7 +186,9 @@
                                                 <b>{{ step.keyword }}</b> {{ step.text }}
                                                 {% if printStepArgs is not null %}
                                                     {% for argument in step.arguments %}
-                                                        <p style="padding-left:0.5em; overflow-x:scroll; white-space:nowrap; font-family:monospace">{{ argument | nl2br }}</p>
+                                                        <p style="padding-left:0.5em; overflow-x:scroll; white-space:nowrap; font-family:monospace">
+                                                            |{% for subarg in argument %} {{ subarg | nl2br}} | {% endfor %}
+                                                        </p>
                                                     {% endfor %}
                                                 {% endif %}
                                                 {% if step.exception is not null %}
@@ -290,8 +292,7 @@
         $("#scenario-overview .feature[data-id='" + featureId + "']").show();
     }
     $(function () {
-        // hacky fix bug with destroyed layout cause JS error here
-        //$('.collapse').collapse();
+        $('.collapse').collapse();
 
         $('.filters').click()
         {


### PR DESCRIPTION
When uses multi agruments like:

    And I fill in the following:
      | settings_optionsModel_0_minWeight | 5  |
      | settings_optionsModel_0_maxWeight | 8  |
      | settings_optionsModel_0_rate      | 67 |

it generate the error:

```
PHP Warning:  nl2br() expects parameter 1 to be string, array given in .../vendor/twig/twig/lib/Twig/Environment.php(458) : eval()'d code on line 405
PHP Stack trace:
PHP   1. {main}() .../vendor/behat/behat/bin/behat:0
PHP   2. Symfony\Component\Console\Application->run() .../vendor/behat/behat/bin/behat:34
PHP   3. Behat\Testwork\Cli\Application->doRun() .../vendor/symfony/console/Application.php:122
PHP   4. Symfony\Component\Console\Application->doRun() .../vendor/behat/behat/src/Behat/Testwork/Cli/Application.php:124
PHP   5. Symfony\Component\Console\Application->doRunCommand() .../vendor/symfony/console/Application.php:191
PHP   6. Symfony\Component\Console\Command\Command->run() .../vendor/symfony/console/Application.php:830
PHP   7. Behat\Testwork\Cli\Command->execute() .../vendor/symfony/console/Command/Command.php:255
PHP   8. Behat\Testwork\Tester\Cli\ExerciseController->execute() .../vendor/behat/behat/src/Behat/Testwork/Cli/Command.php:63
PHP   9. Behat\Testwork\Tester\Cli\ExerciseController->testSpecifications() .../vendor/behat/behat/src/Behat/Testwork/Tester/Cli/ExerciseController.php:108
PHP  10. Behat\Testwork\Ordering\OrderedExercise->tearDown() .../vendor/behat/behat/src/Behat/Testwork/Tester/Cli/ExerciseController.php:150
PHP  11. Behat\Testwork\EventDispatcher\Tester\EventDispatchingExercise->tearDown() .../vendor/behat/behat/src/Behat/Testwork/Ordering/OrderedExercise.php:94
PHP  12. Behat\Testwork\EventDispatcher\TestworkEventDispatcher->dispatch() .../vendor/behat/behat/src/Behat/Testwork/EventDispatcher/Tester/EventDispatchingExercise.php:84
PHP  13. Symfony\Component\EventDispatcher\EventDispatcher->doDispatch() .../vendor/behat/behat/src/Behat/Testwork/EventDispatcher/TestworkEventDispatcher.php:39
PHP  14. call_user_func:{.../vendor/symfony/event-dispatcher/EventDispatcher.php:174}() .../vendor/symfony/event-dispatcher/EventDispatcher.php:174
PHP  15. emuse\BehatHTMLFormatter\Formatter\BehatHTMLFormatter->onAfterExercise() .../vendor/symfony/event-dispatcher/EventDispatcher.php:174
PHP  16. emuse\BehatHTMLFormatter\Renderer\BaseRenderer->renderAfterExercise() .../vendor/emuse/behat-html-formatter/src/Formatter/BehatHTMLFormatter.php:388
PHP  17. emuse\BehatHTMLFormatter\Renderer\TwigRenderer->renderAfterExercise() .../vendor/emuse/behat-html-formatter/src/Renderer/BaseRenderer.php:79
PHP  18. Twig_Environment->render() .../vendor/emuse/behat-html-formatter/src/Renderer/TwigRenderer.php:51
PHP  19. Twig_Template->render() .../vendor/twig/twig/lib/Twig/Environment.php:362
PHP  20. Twig_Template->display() .../vendor/twig/twig/lib/Twig/Template.php:417
PHP  21. Twig_Template->displayWithErrorHandling() .../vendor/twig/twig/lib/Twig/Template.php:406
PHP  22. __TwigTemplate_3d8a57dd66c1e54548d2a53c1b977681fbf4ec5dccaf978b5c5dfc1972135413->doDisplay() .../vendor/twig/twig/lib/Twig/Template.php:438
PHP  23. nl2br() .../vendor/twig/twig/lib/Twig/Environment.php(458) : eval()'d code:405
```