### PR TITLE
HTTPS URL

### DIFF
--- a/assets/Twig/css/style.css
+++ b/assets/Twig/css/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700);
 .bs-callout {
   padding: 20px;
   margin: 20px 0;

--- a/assets/Twig/css/style.less
+++ b/assets/Twig/css/style.less
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700);
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700);
 @import "callout.less";
 
 @color-failed: #F56956;


### PR DESCRIPTION
Otherwise fonts won't load if the coverage' HTML is accessed from an HTTPS domain (like, eg, `xxx.gitlab.io`)