### PR TITLE
Using relative screenshot path instead of a hardcoded folder

### DIFF
--- a/src/Classes/Scenario.php
+++ b/src/Classes/Scenario.php
@@ -198,8 +198,10 @@ class Scenario
      */
     public function getScreenshotPath()
     {
-        if (file_exists('results/html/' . $this->screenshotPath)) {
-            return $this->screenshotPath;
+        if (file_exists($this->screenshotPath)) {
+            return "file://" . realpath($this->screenshotPath);
         }
+
+        return false;
     }
 }

--- a/src/Formatter/BehatHTMLFormatter.php
+++ b/src/Formatter/BehatHTMLFormatter.php
@@ -470,7 +470,8 @@ class BehatHTMLFormatter implements Formatter {
         $scenario->setLine($event->getScenario()->getLine());
         $scenario->setScreenshotName($event->getScenario()->getTitle());
         $scenario->setScreenshotPath(
-            'assets/screenshots/' .
+            $this->printer->getOutputPath() .
+            '/assets/screenshots/' .
             preg_replace('/\W/', '', $event->getFeature()->getTitle()) . '/'.
             preg_replace('/\W/', '', $event->getScenario()->getTitle()) . '.png'
         );


### PR DESCRIPTION
This is a minor change for our own purposes, but I am creating a PR in case you guys want to merge it. Basically, the changes boil down to:

* Using a path relative to the output path to hold screenshots, instead of a hardcoded /results/html folder.
* This allows for the generation of independent report folders, each with their own screenshots.