### PR TITLE
Fix undefined variable strScePending in Behat2Renderer.

### DIFF
--- a/src/Renderer/Behat2Renderer.php
+++ b/src/Renderer/Behat2Renderer.php
@@ -63,6 +63,11 @@ class Behat2Renderer implements RendererInterface {
             $sceTotal += count($obj->getPassedScenarios());
         }
 
+        $strScePending = '';
+        if (null!==$obj->getPendingScenarios() && count($obj->getPendingScenarios()) > 0) {
+            $strScePending = ' <strong class="failed">'.count($obj->getPendingScenarios()).' fail</strong>';
+            $sceTotal += count($obj->getPendingScenarios());
+        }
         $strSceFailed = '';
         if (null!==$obj->getFailedScenarios() && count($obj->getFailedScenarios()) > 0) {
             $strSceFailed = ' <strong class="failed">'.count($obj->getFailedScenarios()).' fail</strong>';


### PR DESCRIPTION
Hi,

I get this small notice when formatting results with this plugin:
`PHP Notice:  Undefined variable: strScePending in /root/.composer/vendor/emuse/behat-html-formatter/src/Renderer/Behat2Renderer.php on line 119`

Here is a proposed solution -- looks like we just need to define strScePending.