### PR TITLE
Add overflow auto to card info div

### DIFF
--- a/assets/Twig/css/style.css
+++ b/assets/Twig/css/style.css
@@ -102,6 +102,7 @@ body {
 .card .info {
   padding: 10px;
   height: 130px;
+  overflow: auto;
 }
 .card .footer {
   border-top: 1px solid #f4f4f4;

--- a/assets/Twig/css/style.less
+++ b/assets/Twig/css/style.less
@@ -61,6 +61,7 @@ body {
   .info {
     padding: 10px;
     height: 130px;
+    overflow: auto;
   }
 
   .footer {


### PR DESCRIPTION
Prevent long feature description overflow the info div, showing a scroll bar only when it doesn't fit the available space.