### PR TITLE
Put screenshot folder creation recursively

### DIFF
--- a/src/Context/ScreenshotContext.php
+++ b/src/Context/ScreenshotContext.php
@@ -44,7 +44,7 @@ class ScreenshotContext extends RawMinkContext
 
         // create screenshots directory if it doesn't exist
         if (!file_exists($this->screenshotDir.'/'.$featureFolder)) {
-            mkdir($this->screenshotDir.'/'.$featureFolder);
+            mkdir($this->screenshotDir.'/'.$featureFolder, 0777, true);
         }
 
         $this->saveScreenshot($fileName, $this->screenshotDir.'/'.$featureFolder.'/');


### PR DESCRIPTION
**Why ?**

Folder for screenshot is : 

`reports/behat/assets/screenshots/Testrecipelist/AsauserIshouldseerecipeuntilIeditit.png`

But it cant be create 

`Warning: mkdir(): No such file or directory in vendor/emuse/behat-html-formatter/src/Context/ScreenshotContext.php line 47`

As recurssive option by default is false.
Not recursive by default : `http://php.net/manual/fr/function.mkdir.php`

**How ?**

Put this parameter to true.