### PR TITLE
getRelativeScreenshotPath is part of the scenario

### DIFF
--- a/src/Renderer/Behat2Renderer.php
+++ b/src/Renderer/Behat2Renderer.php
@@ -434,8 +434,8 @@ class Behat2Renderer implements RendererInterface
         if (!empty($exception)) {
             $print .= '
                         <pre class="backtrace">'.$step->getException().'</pre>';
-            if ($feature->getRelativeScreenshotPath()) {
-                $print .= '<a href="'.$feature->getRelativeScreenshotPath().'">Screenshot</a>';
+            if ($scenario->getRelativeScreenshotPath()) {
+                $print .= '<a href="'.$scenario->getRelativeScreenshotPath().'">Screenshot</a>';
             }
         }
         $print .= '


### PR DESCRIPTION
Currently `getRelativeScreenshotPath` is invoked on `$feature`, but the screenshot path is part of  `$scenario`.

Currently when there is an error,  this is causing:

```
Attempted to call an undefined method named "getRelativeScreenshotPath" of class "emuse\BehatHTMLFormatter\Classes\Feature".
```

This PR fixes that issue