### PR TITLE
Behat2 renderer supports step config parameter "print_outp"

### DIFF
--- a/features/behat2_renderer.feature
+++ b/features/behat2_renderer.feature
@@ -1,115 +1,157 @@
-  Feature: Behat2 Renderer
+Feature: Behat2 Renderer
 
-  Background:
-    Given a file named "behat.yml" with:
-      """
-      default:
-        formatters:
-            html:
-                output_path: %paths.base%/build
-        extensions:
-            emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
-                name: html
-                renderer: Behat2
-                file_name: Index
-                print_args: true
-                print_outp: true
-                loop_break: true
-        suites:
-            suite1:
-                paths:    [ "%paths.base%/features/suite1" ]
-            suite2:
-                paths:    [ "%paths.base%/features/suite2" ]
-            suite3:
-                paths:    [ "%paths.base%/features/suite3" ]
-      """
-    Given a file named "features/bootstrap/FeatureContext.php" with:
-      """
-      <?php
-        use Behat\Behat\Context\CustomSnippetAcceptingContext,
-            Behat\Behat\Tester\Exception\PendingException;
-        class FeatureContext implements CustomSnippetAcceptingContext
-        {
-            public static function getAcceptedSnippetType() { return 'regex'; }
-            /** @When /^I give a passing step$/ */
-            public function passingStep() {
-              print_r("I am a passing step");
-              PHPUnit_Framework_Assert::assertEquals(2, 2);
-            }
-            /** @When /^I give a failing step$/ */
-            public function failingStep() {
-              PHPUnit_Framework_Assert::assertEquals(1, 2, 'I am a failing step');
-            }
-            /** * @When /^I give a pending step$/ */
-            public function somethingNotDoneYet() {
-                throw new PendingException();
-            }
-        }
-      """
-
- Scenario: Multiple Suites with multiple results
-    Given a file named "features/suite1/suite_failing_with_passing.feature" with:
-      """
-      Feature: Suite failing with passing scenarios
-        Scenario: Passing scenario
-          Then I give a passing step
-        Scenario: One Failing step
-          Then I give a failing step
-        Scenario: One Pending step
-          Then I give a pending step
-        Scenario: Passing and Pending steps
-          Then I give a passing step
-          Then I give a pending step
-        Scenario: Passing and Failing steps
-          Then I give a passing step
-          Then I give a failing step
-      """
-    Given a file named "features/suite2/suite_passing.feature" with:
-      """
-      Feature: Suite passing
-        Scenario: Passing scenario
-          Then I give a passing step
-      """
-    Given a file named "features/suite3/suite_pending.feature" with:
-      """
-      Feature: Suite with pending scenario
-        Scenario: One pending step
-          Then I give a pending step
-      """
-    When I run "behat --no-colors"
-    Then process output should be:
-      """
-
-      --- FeatureContext has missing steps. Define them with these snippets:
-
-          /**
-           * @Then /^I give a pending step$/
-           */
-          public function iGiveAPendingStep()
-          {
+Background:
+  Given a file named "features/bootstrap/FeatureContext.php" with:
+    """
+    <?php
+      use Behat\Behat\Context\CustomSnippetAcceptingContext,
+          Behat\Behat\Tester\Exception\PendingException;
+      class FeatureContext implements CustomSnippetAcceptingContext
+      {
+          public static function getAcceptedSnippetType() { return 'regex'; }
+          /** @When /^I give a passing step$/ */
+          public function passingStep() {
+            print_r("I am a passing step");
+            PHPUnit_Framework_Assert::assertEquals(2, 2);
+          }
+          /** @When /^I give a failing step$/ */
+          public function failingStep() {
+            PHPUnit_Framework_Assert::assertEquals(1, 2, 'I am a failing step');
+          }
+          /** * @When /^I give a pending step$/ */
+          public function somethingNotDoneYet() {
               throw new PendingException();
           }
+      }
+    """
+
+Scenario: Multiple Suites with multiple results, making sure we output results
+  Given a file named "behat.yml" with:
+    """
+    default:
+      formatters:
+          html:
+              output_path: %paths.base%/build
+      extensions:
+          emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
+              name: html
+              renderer: Behat2
+              file_name: Index
+              print_args: true
+              print_outp: true
+              loop_break: true
+      suites:
+          suite1:
+              paths:    [ "%paths.base%/features/suite1" ]
+          suite2:
+              paths:    [ "%paths.base%/features/suite2" ]
+          suite3:
+              paths:    [ "%paths.base%/features/suite3" ]
+    """
+  And a file named "features/suite1/suite_failing_with_passing.feature" with:
+    """
+    Feature: Suite failing with passing scenarios
+      Scenario: Passing scenario
+        Then I give a passing step
+      Scenario: One Failing step
+        Then I give a failing step
+      Scenario: One Pending step
+        Then I give a pending step
+      Scenario: Passing and Pending steps
+        Then I give a passing step
+        Then I give a pending step
+      Scenario: Passing and Failing steps
+        Then I give a passing step
+        Then I give a failing step
+    """
+  And a file named "features/suite2/suite_passing.feature" with:
+    """
+    Feature: Suite passing
+      Scenario: Passing scenario
+        Then I give a passing step
+    """
+  And a file named "features/suite3/suite_pending.feature" with:
+    """
+    Feature: Suite with pending scenario
+      Scenario: One pending step
+        Then I give a pending step
+    """
+  When I run "behat --no-colors"
+  Then process output should be:
+    """
+
+    --- FeatureContext has missing steps. Define them with these snippets:
+
+        /**
+         * @Then /^I give a pending step$/
+         */
+        public function iGiveAPendingStep()
+        {
+            throw new PendingException();
+        }
 
 
-      """
-    And report file for Behat2 should exists
-    And report file should contain:
-      """
-                      <p class="features">
-                          3 features ( <strong class="passed">1 success</strong> <strong class="failed">2 fail</strong> )
-                      </p>
-                      <p class="scenarios">
-                          7 scenarios ( <strong class="passed">2 success</strong> <strong class="failed">5 fail</strong> )
-                      </p>
-                      <p class="steps">
-                          9 steps ( <strong class="passed">4 success</strong> <strong class="pending">3 pending</strong> <strong class="failed">2 fail</strong> )
-                      </p>
-      """
-    And report file should contain:
-      """
-      I am a passing step
-      """
-    And report file should contain:
-      """
-      I am a failing step
-      """
+    """
+  And report file for Behat2 should exists
+  And report file should contain:
+    """
+                    <p class="features">
+                        3 features ( <strong class="passed">1 success</strong> <strong class="failed">2 fail</strong> )
+                    </p>
+                    <p class="scenarios">
+                        7 scenarios ( <strong class="passed">2 success</strong> <strong class="failed">5 fail</strong> )
+                    </p>
+                    <p class="steps">
+                        9 steps ( <strong class="passed">4 success</strong> <strong class="pending">3 pending</strong> <strong class="failed">2 fail</strong> )
+                    </p>
+    """
+  And report file should contain:
+    """
+    I am a passing step
+    """
+  And report file should contain:
+    """
+    I am a failing step
+    """
+
+Scenario: Make sure we respect if a user does not want to print output
+  Given a file named "behat.yml" with:
+    """
+    default:
+      formatters:
+          html:
+              output_path: %paths.base%/build
+      extensions:
+          emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
+              name: html
+              renderer: Behat2
+              file_name: Index
+              print_args: true
+              print_outp: false
+              loop_break: true
+      suites:
+          suite1:
+              paths:    [ "%paths.base%/features/suite1" ]
+          suite2:
+              paths:    [ "%paths.base%/features/suite2" ]
+          suite3:
+              paths:    [ "%paths.base%/features/suite3" ]
+    """
+  And a file named "features/suite1/suite_passing_failing.feature" with:
+    """
+    Feature: Suite failing with passing scenarios
+      Scenario: Passing scenario
+        Given I give a passing step
+      Scenario: One Failing step
+        Given I give a failing step
+    """
+  When I run "behat --no-colors"
+  Then report file for Behat2 should exists
+  And report file should not contain:
+    """
+    I am a passing step
+    """
+  And report file should contain:
+    """
+    I am a failing step
+    """

--- a/features/behat2_renderer.feature
+++ b/features/behat2_renderer.feature
@@ -1,4 +1,4 @@
-  Feature: Twig Renderer
+  Feature: Behat2 Renderer
 
   Background:
     Given a file named "behat.yml" with:
@@ -10,7 +10,7 @@
         extensions:
             emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
                 name: html
-                renderer: Twig
+                renderer: Behat2
                 file_name: Index
                 print_args: true
                 print_outp: true
@@ -32,12 +32,13 @@
         {
             public static function getAcceptedSnippetType() { return 'regex'; }
             /** @When /^I give a passing step$/ */
-            public function passingStep() { 
+            public function passingStep() {
+              print_r("I am a passing step");
               PHPUnit_Framework_Assert::assertEquals(2, 2);
             }
             /** @When /^I give a failing step$/ */
-            public function failingStep() { 
-              PHPUnit_Framework_Assert::assertEquals(1, 2);
+            public function failingStep() {
+              PHPUnit_Framework_Assert::assertEquals(1, 2, 'I am a failing step');
             }
             /** * @When /^I give a pending step$/ */
             public function somethingNotDoneYet() {
@@ -91,17 +92,24 @@
 
 
       """
-    And report file for Twig should exists
+    And report file for Behat2 should exists
     And report file should contain:
       """
-      2 features failed of 3
+                      <p class="features">
+                          3 features ( <strong class="passed">1 success</strong> <strong class="failed">2 fail</strong> )
+                      </p>
+                      <p class="scenarios">
+                          7 scenarios ( <strong class="passed">2 success</strong> <strong class="failed">5 fail</strong> )
+                      </p>
+                      <p class="steps">
+                          9 steps ( <strong class="passed">4 success</strong> <strong class="pending">3 pending</strong> <strong class="failed">2 fail</strong> )
+                      </p>
       """
     And report file should contain:
       """
-      5 scenarios failed of 7
+      I am a passing step
       """
     And report file should contain:
       """
-      2 steps failed of 6
+      I am a failing step
       """
-

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -335,15 +335,18 @@ class FeatureContext implements Context, SnippetAcceptingContext
 
 
     /**
-     * @Given report file should exists
+     * @Given /report file for (Twig|Behat2) should exists/
      */
-    public function reportFileShouldExists()
+    public function reportFileShouldExists(string $reportType)
     {
-        $files = array(
-            $this->reportDir . 'Index.html',
-            $this->reportDir . 'assets/Twig/css/style.css',
-            $this->reportDir . 'assets/Twig/css/style.less',
-        );
+        $files = [];
+        if ($reportType === 'Behat2') {
+            $files[] = $this->reportDir . 'Index.html';
+        } elseif ($reportType === 'Twig') {
+            $files[] = $this->reportDir . 'Index.html';
+            $files[] = $this->reportDir . 'assets/Twig/css/style.css';
+            $files[] = $this->reportDir . 'assets/Twig/css/style.less';
+        }
 
         foreach ($files as $file) {
             PHPUnit_Framework_Assert::assertFileExists($file);

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -365,6 +365,18 @@ class FeatureContext implements Context, SnippetAcceptingContext
         PHPUnit_Framework_Assert::assertContains($string->getRaw(), file_get_contents($index));
     }
 
+    /**
+     * @Given report file should not contain:
+     *
+     * @param PyStringNode $string
+     */
+    public function reportFileShouldNotContain(PyStringNode $string)
+    {
+        $index = $this->reportDir . 'Index.html';
+
+        PHPUnit_Framework_Assert::assertNotContains($string->getRaw(), file_get_contents($index));
+    }
+
     private function getExitCode()
     {
         return $this->process->getExitCode();

--- a/src/Renderer/Behat2Renderer.php
+++ b/src/Renderer/Behat2Renderer.php
@@ -439,10 +439,12 @@ class Behat2Renderer implements RendererInterface
             }
         }
 
-        $output = $step->getOutput();
-        if (!empty($output)) {
-            $print .= '
+        if ($obj->getPrintOutputs() === true) {
+            $output = $step->getOutput();
+            if (!empty($output)) {
+                $print .= '
                         <pre class="backtrace">'.$output.'</pre>';
+            }
         }
 
         $print .= '

--- a/src/Renderer/Behat2Renderer.php
+++ b/src/Renderer/Behat2Renderer.php
@@ -438,6 +438,13 @@ class Behat2Renderer implements RendererInterface
                 $print .= '<a href="'.$scenario->getRelativeScreenshotPath().'">Screenshot</a>';
             }
         }
+
+        $output = $step->getOutput();
+        if (!empty($output)) {
+            $print .= '
+                        <pre class="backtrace">'.$output.'</pre>';
+        }
+
         $print .= '
                     </li>';
 


### PR DESCRIPTION
Hello,
Right now, the Behat2 renderer does not support printing output from the steps. If a step prints somewith with "print_r()", "var_dump()", etc. then the HTML page won't display that.

I would like to propose supporting the parameter "print_outp" for the Behat2 renderer, and have provided this change for that.
With the change comes also an additional Behat test for the feature.

Is there any chance this gets into the master branch, and update the composer package with it?
Our project would be helped very much if it did, and I am happy to help to get it through.

I also have another branch where I did create a Docker container that is able to execute the tests locally. If you are interested, I could prepare another PR with that, potentially adding Github actions with it.

Please let me know what you think.

Best regards,
Martin